### PR TITLE
Expand command line options for readability

### DIFF
--- a/bin/update-gh-pages.sh
+++ b/bin/update-gh-pages.sh
@@ -7,10 +7,10 @@ safely () {
     fi
 }
 
-safely git branch -f gh-pages HEAD
+safely git branch --force gh-pages HEAD
 safely git checkout gh-pages
 safely sass --update css/reveal-override.scss
-safely git add -f css/*.css css/*.map
-safely git commit -m'Latest .css and .css.map files for publishing via gh-pages'
-safely git push -f github gh-pages
+safely git add --force css/*.css css/*.map
+safely git commit --message 'Latest .css and .css.map files for publishing via gh-pages'
+safely git push --force github gh-pages
 safely git checkout -


### PR DESCRIPTION
Long command line arguments are easier to remember and recognize. This
change improves the readability of the update script for those of us
who have a hard time with remembering what the short options do.