### PR TITLE
Add instructions for Python 3 users

### DIFF
--- a/USAGE.md
+++ b/USAGE.md
@@ -123,7 +123,13 @@ The files must be served by a local web server.
 If you have Python installed, the easiest way is probably to run this
 one-line command from the repository:
 
+Python 2:
+
     python -m SimpleHTTPServer 8000
+
+Python 3:
+
+    python -m http.server 8000
 
 #### Apache
 


### PR DESCRIPTION
The `SimpleHTTPServer` module has been merged into `http.server` in
Python 3.0. This change adds instructions for Python 3 users on how to
serve the presentation locally.