### PR TITLE
css: use Work Sans in the new theme

### DIFF
--- a/css/reveal-override.scss
+++ b/css/reveal-override.scss
@@ -6,7 +6,7 @@
 
 .reveal {
     h1, h2, h3, h4, h5, h6, div, span {
-        font-family: "Arial", sans-serif;
+        font-family: "Work Sans", sans-serif;
     }
 
     font-size: 2rem;


### PR DESCRIPTION
It was still set to Arial in the new theme