### PR TITLE
Adapt styles for divider layouts

### DIFF
--- a/css/_divider.scss
+++ b/css/_divider.scss
@@ -43,7 +43,7 @@
 
         h2 {
             font-size: 1em;
-            top: 65%;
+            top: 70%;
         }
     }
 
@@ -83,10 +83,47 @@
 
         h2 {
             font-size: 1em;
-            top: 65%;
+            top: 70%;
         }
     }
 
     @include copyright(white, $pine);
 }
 
+
+/* divider customization to have an image covering the right-half part of the slide entirely */
+#divider, #divider-blue,
+#subdivider, #subdivider-blue {
+    margin: 0;
+    width: 100%;
+    height: 100%;
+    padding: 0;
+
+    h1, h2 {
+        /* Margin percentages (e.g. 5%) are treated as being relative to the
+        containing element's *width*, even the top and bottom margins. */
+        margin: $section-top-margin / $aspect-ratio $section-left-margin;
+    }
+
+    a {
+        position: absolute;
+        top: 0;
+        right: 0;
+        height: 100%;
+        width: 50%;
+        overflow: hidden;
+
+        img {
+            position: absolute;
+            height: 100%;
+            max-height: 100%;
+            width: 100%;
+            max-width: 100%;
+            margin: 0;
+            left: auto;
+            right: auto;
+            border-radius: 0;
+            padding-top: 4px;
+        }
+    }
+}

--- a/css/_slides.scss
+++ b/css/_slides.scss
@@ -4,19 +4,18 @@
 
     > section {
         border: $debug 2px red;
-
-        /* Margin percentages (e.g. 5%) are treated as being relative to the
-           containing element's *width*, even the top and bottom margins. */
-        margin: $section-top-margin / $aspect-ratio $section-left-margin;
-        width: $section-width;
-        height: $section-height;
+        margin: 0;
         padding: 0;
+        width: 100%;
+        height: 100%;
 
         section {
-            margin: 0;
+            /* Margin percentages (e.g. 5%) are treated as being relative to the
+            containing element's *width*, even the top and bottom margins. */
+            margin: $section-top-margin / $aspect-ratio $section-left-margin;
+            width: $section-width;
+            height: $section-height;
             padding: 0;
-            width: 100%;
-            height: 100%;
         }
 
         img {

--- a/css/_thanks.scss
+++ b/css/_thanks.scss
@@ -10,8 +10,11 @@
         margin: 0;
 
         > section {
-            width: 100%;
-            height: 100%;
+            /* Margin percentages (e.g. 5%) are treated as being relative to the
+            containing element's *width*, even the top and bottom margins. */
+            margin: $section-top-margin / $aspect-ratio $section-left-margin;
+            width: $section-width;
+            height: $section-height;
         }
 
         background:


### PR DESCRIPTION
CC: @cbosdo 

This PR fixes the `divider` layout and all the derived layouts (`subdivider`, `divider-blue`, etc)

#### Before
![before-template](https://user-images.githubusercontent.com/7080830/120981342-e1e74d80-c777-11eb-94b3-2059eff6ea34.png)

#### After
![after-template](https://user-images.githubusercontent.com/7080830/120981368-e6ac0180-c777-11eb-8e49-df0d79056e14.png)



### TODO
NB: currently it breaks a bit the `live-demo` and the `full-screen` layouts. The fixes create an offset for the two layouts, see below
![issue](https://user-images.githubusercontent.com/7080830/120981563-122eec00-c778-11eb-9b94-82a57bfa364a.png)


