### PR TITLE
js: disable RevealMath plugin by default

### DIFF
--- a/index.html
+++ b/index.html
@@ -88,9 +88,8 @@
     <script src="reveal.js/plugin/markdown/markdown.js"></script>
     <script src="reveal.js/plugin/highlight/highlight.js"></script>
     <script src="reveal.js/plugin/notes/notes.js"></script>
-    <script src="reveal.js/plugin/math/math.js"></script>
     <script src="reveal.js/plugin/zoom/zoom.js"></script>
-    <script src="reveal.js-menu/menu.js"></script> 
+    <script src="reveal.js-menu/menu.js"></script>
     <script src="js/reveal.js"></script>
 
     <script src="qrcodejs/qrcode.js"></script>

--- a/js/reveal.js
+++ b/js/reveal.js
@@ -21,7 +21,8 @@ Reveal.initialize({
     transition: 'none', // default/cube/page/concave/zoom/linear/fade/none
 
     // Optional libraries used to extend on reveal.js
-    plugins: [ RevealMarkdown, RevealHighlight, RevealNotes, RevealMenu, RevealZoom, RevealMath ],
+    plugins: [ RevealMarkdown, RevealHighlight, RevealNotes, RevealMenu, RevealZoom ],
+    // Disabled: RevealMath, which depends on MathJax
 
     menu: {
         themes: false,


### PR DESCRIPTION
It's hardcoded to pull down an old version of MathJax at runtime from:
https://cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.0/MathJax.js

This is unnecessary unless it's actually going to be used.

Signed-off-by: David Disseldorp <ddiss@suse.de>